### PR TITLE
alert user where name.app is located

### DIFF
--- a/chrome-ssb.sh
+++ b/chrome-ssb.sh
@@ -94,3 +94,10 @@ cat > "$resourcePath/en.lproj/InfoPlist.strings" <<EOF
 CFBundleDisplayName = "$name";
 CFBundleName = "$name";
 EOF
+
+### tell the user where the app is located so that they can move it to
+### /Applications if they wish
+/bin/cat <<EOF
+Finished! The app has been installed in 
+$appRoot/$name.app
+EOF


### PR DESCRIPTION
Its not hard to figure out where the name.app is eventually located, but it would make it even easier to just tell users where it is. This PR just alerts the user the directory in which they should look for the name.app (so they can install it in `/Applications` if they so choose. 
