### PR TITLE
make the generated SSB's retina-enabled

### DIFF
--- a/chrome-ssb.sh
+++ b/chrome-ssb.sh
@@ -81,6 +81,8 @@ EOF
 <string>$name</string>
 <key>CFBundleIconFile</key>
 <string>icon.icns</string>
+<key>NSHighResolutionCapable</key>
+<string>True</string>
 </dict>
 </plist>
 EOF


### PR DESCRIPTION
Fix from: http://www.hongkiat.com/blog/mbp-retina-blurry-text/ and http://apple.stackexchange.com/questions/69038/open-in-low-resolution-checkbox-on-retina-macbook-pro-checked-and-disabled

Tested on 10.8.5 with Chrome Version 29.0.1547.76.
