### PR TITLE
launch chrome directly (vs via a symlink)

### DIFF
--- a/chrome-ssb.sh
+++ b/chrome-ssb.sh
@@ -58,14 +58,14 @@ if [ -f "$icon" ] ; then
     fi
 fi
 
-### link the chrome executable
-/bin/ln -s "$chromeExecPath" "$execPath/$name Chrome"
-
 ### Create the wrapper executable
 /bin/cat >"$execPath/$name" <<EOF
-#!/bin/bash
-ABSPATH=\$(cd "\$(dirname "\$0")"; pwd)
-exec "\$ABSPATH/$name Chrome" --app="$url" --user-data-dir="\$ABSPATH/../Profile" "\$@"
+#!/bin/sh
+iam="\$0"
+profDir=\$(dirname "\$iam")
+profDir=\$(dirname "\$profDir")
+profDir="\$profDir/Profile"
+exec '$chromeExecPath' --app="$url" --user-data-dir="\$profDir" "\$@"
 EOF
 /bin/chmod +x "$execPath/$name"
 


### PR DESCRIPTION
- Now behaves like original script and AppleScript. 
  https://www.lessannoyingcrm.com/blog/2010/08/149/create+application+shortcuts+in+google+chrome+on+a+mac
- No longer needs/creates a symlink to Chrome app.
- Doesn't have PDF plugin loading issue any longer.

fixes https://github.com/lhl/chrome-ssb-osx/issues/8
