### PR TITLE
absolute paths on dirname calls

### DIFF
--- a/chrome-ssb.sh
+++ b/chrome-ssb.sh
@@ -62,8 +62,8 @@ fi
 /bin/cat >"$execPath/$name" <<EOF
 #!/bin/sh
 iam="\$0"
-profDir=\$(dirname "\$iam")
-profDir=\$(dirname "\$profDir")
+profDir=\$(/usr/bin/dirname "\$iam")
+profDir=\$(/usr/bin/dirname "\$profDir")
 profDir="\$profDir/Profile"
 exec '$chromeExecPath' --app="$url" --user-data-dir="\$profDir" "\$@"
 EOF


### PR DESCRIPTION
This is minor, but I made all paths absolute to be consistent with the rest of the script in case people have strange aliases on dirname (which I've admittedly never heard of...)
