### PR TITLE
Hybrid symlink approach for Mavericks launcher issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ I've updated it a bit to work better:
 **Note:** Finder may not pick up the icon (shows up as invisible) if you have the creation target folder active/open. You can make it show up by moving the App to a different folder. If you know a workaround, please send a pull request...
 
 ## Notes
-* This script now makes a copy of the 'Google Chrome' launcher executable stub (it is pretty small, about 13KB) instead of symlinking to solve 10.9 compatibility issues (see #22). The executable points to a specific version of the Google Chrome Framework (../Versions/[VERSION]/Google Chrome Framework.framework/Google Chrome Framework). I don't know what the behavior will be as updates are released...
+* This script now makes a copy of the 'Google Chrome' launcher executable stub at application start (it is pretty small, about 13KB) instead of symlinking to solve 10.9 compatibility issues (see #22). The executable points to a specific version of the Google Chrome Framework (../Versions/[VERSION]/Google Chrome Framework.framework/Google Chrome Framework).
 * Copying the launcher executable instead of symlinking will break OS X Gatekeeper's code signing. This shouldn't normally be a problem, but is discussed in depth in Issue #23
 
 ## TODO

--- a/chrome-ssb.sh
+++ b/chrome-ssb.sh
@@ -58,14 +58,14 @@ if [ -f "$icon" ] ; then
     fi
 fi
 
-# In Mavericks, symlinking no longer works (see #22) however if we copy
-# the binary stub it does.  Fine.
-/bin/cp "$chromeExecPath" "$execPath/$name Chrome"
+# Save a symlink to the location of the Chrome executable to be copied when the SSB is started.
+/bin/ln -s "$chromeExecPath" "$execPath/Chrome"
 
 ### Create the wrapper executable
 /bin/cat >"$execPath/$name" <<EOF
 #!/bin/sh
 ABSPATH=\$(cd "\$(dirname "\$0")"; pwd)
+/bin/cp "\$ABSPATH/Chrome" "\$ABSPATH/$name Chrome"
 exec "\$ABSPATH/$name Chrome" --app="$url" --user-data-dir="\$ABSPATH/../Profile" "\$@"
 EOF
 /bin/chmod +x "$execPath/$name"


### PR DESCRIPTION
This approach should ensure that SSBs will continue to track Chrome updates as the launcher included in the real Google Chrome app folder is updated.  Saves a symlink to the location of the real executable at SSB creation time, and recopies at launch in case any Chrome updates were applied in the interim.  The small size of the executable should make this copy negligible (could probably do an rsync to avoid unnecessary copies, but I'm not sure if we can assume rsync is available across all relevant versions of OS X).
